### PR TITLE
Fix: Python 3.13 compatibility (HA 2025.12.1+)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+Source ____mampfes/ha_freeair_connect___
+
 # FreeAir Connect
 
 This component adds data from [FreeAir Connect](https://www.freeair-connect.de) to Home Assistant.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-Source ____mampfes/ha_freeair_connect___
-
 # FreeAir Connect
 
 This component adds data from [FreeAir Connect](https://www.freeair-connect.de) to Home Assistant.

--- a/custom_components/freeair_connect/FreeAir/__init__.py
+++ b/custom_components/freeair_connect/FreeAir/__init__.py
@@ -412,7 +412,6 @@ class Connect:
         self._fad = None
         self._error_text = {}
         self._session = requests.Session()
-        # FIX: Set default headers for the session to avoid Brotli issues
         self._session.headers.update(_DEFAULT_HEADERS)
 
     @property
@@ -440,7 +439,6 @@ class Connect:
         ).raise_for_status()
 
     def fetch(self):
-        # FIX: Initialize blob to None and properly handle exceptions
         blob = None
         try:
             self._login()
@@ -449,14 +447,12 @@ class Connect:
             self._fad = None
             self._error_text = {}
             _LOGGER.error(f"fetch failed for SN {self._serial_no}: {error}")
-            return  # FIX: Return early on error to prevent UnboundLocalError
+            return
 
-        # FIX: Additional safety check
         if blob is None:
             _LOGGER.error(f"No data received for SN {self._serial_no}")
             return
 
-        # split blob
         parts = blob.split("timestamp")
         encrypted_data = parts[0]
         timestamp = datetime.strptime(parts[1], "%Y-%m-%d %H:%M:%S")
@@ -467,7 +463,6 @@ class Connect:
         self._fetchtime = timestamp
 
         if self._fad.error_state not in (0, 22):
-            # fetch error string
             self._fetch_error()
         else:
             self._error_text = {}
@@ -493,8 +488,6 @@ class Connect:
         }
 
     def _parse(self, encrypted_data, timestamp, version, version_fa100):
-        # encrypted_data = "PgiFboacxLklQ3gz8APQ87wwROYqCWCKViRZR0XCZo72CrWG3Cn91Dr+it7SfJwD"
-        # encrypted_data = urllib.parse.unquote(encrypted_data) # this is probably not needed!
         encrypted_data = base64.b64decode(encrypted_data)
 
         version_numbers = version.split("x")

--- a/custom_components/freeair_connect/FreeAir/__init__.py
+++ b/custom_components/freeair_connect/FreeAir/__init__.py
@@ -366,6 +366,7 @@ class Data:
                 / (self.temp_extract - self.temp_outdoor)
             )
             + 0.5,
+            1,
         )
 
     def _as_signed(self, value, potenz):
@@ -398,13 +399,8 @@ class Data:
         return None
 
 
-# FIX: Custom headers to avoid Brotli encoding issues with Python 3.13
 _DEFAULT_HEADERS = {
-    "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
-    "Accept-Encoding": "gzip, deflate",  # Explicitly exclude 'br' (Brotli)
-    "Accept-Language": "en-US,en;q=0.5",
-    "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36",
-    "Connection": "keep-alive",
+    "Accept-Encoding": "gzip, deflate",
 }
 
 
@@ -468,7 +464,7 @@ class Connect:
         version_fa100 = parts[3]
 
         self._fad = self._parse(encrypted_data, timestamp, version, version_fa100)
-        self._fetchtime = timestamp  # FIX: Update fetchtime on successful fetch
+        self._fetchtime = timestamp
 
         if self._fad.error_state not in (0, 22):
             # fetch error string


### PR DESCRIPTION
## Summary

This PR fixes two critical issues that prevent the integration from working with Home Assistant 2025.12.1 and later (Python 3.13).

## Issues Fixed

### 1. UnboundLocalError in `fetch()` method
UnboundLocalError: cannot access local variable 'blob' where it is not associated with a value


**Cause:** When an exception occurs during `_login()` or `_fetch_data()`, the code continues to execute `blob.split("timestamp")` even though `blob` was never assigned.

**Fix:** 
- Initialize `blob = None` at the start of the method
- Add early `return` after exception handling
- Add safety check before processing `blob`

### 2. Brotli decoding error
fetch failed for SN XXXXX: ('Received response with content-encoding: br, but failed to decode it.', error("brotli: decoder process called with data when 'can_accept_more_data()' is False"))


**Cause:** Python 3.13's Brotli library has compatibility issues with the requests library.

**Fix:** Add explicit HTTP headers that exclude Brotli (`br`) from `Accept-Encoding`.

### 3. Minor: Update fetchtime

Added missing `self._fetchtime = timestamp` to properly track the last successful fetch time.

## Testing

- ✅ Tested with Home Assistant 2025.12.1
- ✅ Tested with Python 3.13
- ✅ Multiple FreeAir devices successfully fetching data
- ✅ No more errors in logs

## Breaking Changes

None. This is a backwards-compatible fix.