### PR TITLE
Fix homeassistant integration after api changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,15 @@ In case you would like to install manually:
 
 This component provides sensors for all major values provided by a FreeAir device.
 
+## Local Server Mode
+
+Instead of polling the freeair-connect.de cloud, the integration can run a local HTTP server that receives data directly from the device. To use this mode:
+
+1. Enable **"Lokalen Server aktivieren"** / **"Enable local server"** during setup, or afterwards via **Settings → Integrations → FreeAir Connect → Configure**.
+2. Using the FreeAir USB app, configure the device's server address to the IP address of your Home Assistant instance.
+
+> **Note:** The local server listens on port 80. Make sure this port is not already in use on your Home Assistant host.
+
 ## Refresh Service
 
 If you want to trigger a manual refresh of all device data, you can call the service:

--- a/custom_components/freeair_connect/FreeAir/__init__.py
+++ b/custom_components/freeair_connect/FreeAir/__init__.py
@@ -306,9 +306,17 @@ class Data:
         return self._extract([_BitSlice(34, 4, 1), _BitSlice(21, 0, 7)])
 
     @property
+    def _is_crypt256(self):
+        parts = self._version.split("x")
+        major = int(parts[0])
+        minor = int(parts[1])
+        return not (major == 2 and (minor <= 13 or minor == 20 or minor == 21))
+
+    @property
     def rssi(self):
-        val = self._extract([_BitSlice(47, 0, 8)])
-        return self._as_signed(val, 8)
+        # AES-256 firmware stores RSSI at byte 43; AES-128 at byte 47
+        byte_pos = 43 if self._is_crypt256 else 47
+        return self._as_signed(self._data[byte_pos], 8)
 
     @property
     def filter_status_supply(self):

--- a/custom_components/freeair_connect/FreeAir/__init__.py
+++ b/custom_components/freeair_connect/FreeAir/__init__.py
@@ -503,7 +503,8 @@ class Connect:
 
     def parse(self, encrypted_bytes, timestamp, version, version_fa100):
         """Decrypt and parse raw bytes pushed by the device (server mode)."""
-        self._fad = self._decrypt(encrypted_bytes, timestamp, version, version_fa100)
+        # Server mode always uses AES-128 regardless of firmware version
+        self._fad = self._decrypt_aes128(encrypted_bytes, timestamp, version, version_fa100)
         self._fetchtime = timestamp
 
         if self._fad.error_state not in (0, 22):
@@ -526,6 +527,13 @@ class Connect:
 
     def _parse(self, encrypted_data, timestamp, version, version_fa100):
         return self._decrypt(base64.b64decode(encrypted_data), timestamp, version, version_fa100)
+
+    def _decrypt_aes128(self, encrypted_bytes, timestamp, version, version_fa100):
+        iv = binascii.unhexlify("000102030405060708090a0b0c0d0e0f")
+        pw = self._password.ljust(16, "0")
+        rijndael = RijndaelCbc(key=pw, iv=iv, padding=ZeroPadding(16), block_size=16)
+        data = rijndael.decrypt(encrypted_bytes)
+        return Data(data, timestamp, version, version_fa100)
 
     def _decrypt(self, encrypted_bytes, timestamp, version, version_fa100):
         version_numbers = version.split("x")

--- a/custom_components/freeair_connect/FreeAir/__init__.py
+++ b/custom_components/freeair_connect/FreeAir/__init__.py
@@ -406,14 +406,17 @@ _DEFAULT_HEADERS = {
 
 
 class Connect:
-    def __init__(self, serial_no, password):
+    def __init__(self, serial_no, password, server_mode=False):
         self._serial_no = serial_no
         self._password = password
+        self._server_mode = server_mode
         self._fetchtime = None
         self._fad = None
         self._error_text = {}
         self._session = requests.Session()
         self._session.headers.update(_DEFAULT_HEADERS)
+        self._comfort_level = None
+        self._operation_mode = None
 
     @property
     def fetchtime(self):
@@ -490,9 +493,33 @@ class Connect:
             "de": err["de"]["long"],
         }
 
-    def _parse(self, encrypted_data, timestamp, version, version_fa100):
-        encrypted_data = base64.b64decode(encrypted_data)
+    def parse(self, encrypted_bytes, timestamp, version, version_fa100):
+        """Decrypt and parse raw bytes pushed by the device (server mode)."""
+        self._fad = self._decrypt(encrypted_bytes, timestamp, version, version_fa100)
+        self._fetchtime = timestamp
 
+        if self._fad.error_state not in (0, 22):
+            try:
+                self._fetch_error()
+            except Exception:
+                pass
+        else:
+            self._error_text = {}
+
+        if self._comfort_level is None:
+            self._comfort_level = self._fad.comfort_level
+        self._fad.set_comfort_level(self._comfort_level)
+
+        if self._operation_mode is None:
+            self._operation_mode = self._fad.operation_mode
+        self._fad.set_operation_mode(self._operation_mode)
+
+        return self._fad
+
+    def _parse(self, encrypted_data, timestamp, version, version_fa100):
+        return self._decrypt(base64.b64decode(encrypted_data), timestamp, version, version_fa100)
+
+    def _decrypt(self, encrypted_bytes, timestamp, version, version_fa100):
         version_numbers = version.split("x")
         major = int(version_numbers[0])
         minor = int(version_numbers[1])
@@ -503,35 +530,35 @@ class Connect:
             iv = "30313233343536373839303132333435"
             size = 32
 
-        # prepare initialization vector
         iv = binascii.unhexlify(iv)
-        
-        # fill password to 16 characters with zeros
         pw = self._password.ljust(size, "0")
 
         rijndael = RijndaelCbc(key=pw, iv=iv, padding=ZeroPadding(16), block_size=16)
-        data = rijndael.decrypt(encrypted_data)
+        data = rijndael.decrypt(encrypted_bytes)
 
-        # extract data
         return Data(data, timestamp, version, version_fa100)
 
     def set_comfort_level(self, value):
         assert value >= 1 and value <= 5
-        self._fad.set_comfort_level(value)
-        self.set_cl_and_om(value, self._fad.operation_mode)
+        self.set_cl_and_om(value, self._operation_mode or self._fad.operation_mode)
 
     def set_operation_mode(self, value):
         assert value >= 1 and value <= 4
-        self._fad.set_operation_mode(value)
-        self.set_cl_and_om(self._fad.comfort_level, value)
+        self.set_cl_and_om(self._comfort_level or self._fad.comfort_level, value)
 
     def set_cl_and_om(self, comfort_level, operation_mode):
         if operation_mode == 0:
             operation_mode = 1
-        data = {
-            "serialnumber": self._serial_no,
-            "CL": comfort_level,
-            "OM": operation_mode,
-        }
-        r = self._session.post(f"{_BASE_URL}/button.php", data=data)
-        r.raise_for_status()
+        self._comfort_level = comfort_level
+        self._operation_mode = operation_mode
+        if self._fad:
+            self._fad.set_comfort_level(comfort_level)
+            self._fad.set_operation_mode(operation_mode)
+        if not self._server_mode:
+            data = {
+                "serialnumber": self._serial_no,
+                "CL": comfort_level,
+                "OM": operation_mode,
+            }
+            r = self._session.post(f"{_BASE_URL}/button.php", data=data)
+            r.raise_for_status()

--- a/custom_components/freeair_connect/FreeAir/__init__.py
+++ b/custom_components/freeair_connect/FreeAir/__init__.py
@@ -1,7 +1,6 @@
 import base64
 import binascii
 import logging
-import urllib.parse
 from datetime import datetime
 
 import requests
@@ -399,6 +398,8 @@ class Data:
         return None
 
 
+_BASE_URL = "https://freeair-connect.de/api"
+
 _DEFAULT_HEADERS = {
     "Accept-Encoding": "gzip, deflate",
 }
@@ -428,36 +429,34 @@ class Connect:
         return self._error_text
 
     def _login(self):
-        self._session.post(
-            "https://www.freeair-connect.de/index.php",
-            data={"serialnumber": self._serial_no},
-        ).raise_for_status()
-
-        self._session.post(
-            "https://www.freeair-connect.de/index.php",
-            data={"serial_password": self._password},
-        ).raise_for_status()
+        r = self._session.post(
+            f"{_BASE_URL}/login.php",
+            data={"serialnumber": self._serial_no, "serial_password": self._password},
+        )
+        r.raise_for_status()
+        response = r.json()
+        if not response.get("showLogout"):
+            raise Exception(f"Login failed: {response.get('serverMessage', 'unknown error')}")
 
     def fetch(self):
-        blob = None
+        entry = None
         try:
             self._login()
-            blob = self._fetch_data()
+            entry = self._fetch_data()
         except Exception as error:
             self._fad = None
             self._error_text = {}
             _LOGGER.error(f"fetch failed for SN {self._serial_no}: {error}")
             return
 
-        if blob is None:
+        if entry is None:
             _LOGGER.error(f"No data received for SN {self._serial_no}")
             return
 
-        parts = blob.split("timestamp")
-        encrypted_data = parts[0]
-        timestamp = datetime.strptime(parts[1], "%Y-%m-%d %H:%M:%S")
-        version = parts[2]
-        version_fa100 = parts[3]
+        encrypted_data = entry["log"]
+        timestamp = datetime.strptime(entry["timestamp"], "%Y-%m-%d %H:%M:%S")
+        version = entry["versionCC3200"]
+        version_fa100 = entry["versionMain"]
 
         self._fad = self._parse(encrypted_data, timestamp, version, version_fa100)
         self._fetchtime = timestamp
@@ -468,23 +467,27 @@ class Connect:
             self._error_text = {}
 
     def _fetch_data(self):
-        r = self._session.post("https://www.freeair-connect.de/getDataHexAjax.php")
+        r = self._session.get(
+            f"{_BASE_URL}/values.php",
+            params={"serialnumber": self._serial_no},
+        )
         r.raise_for_status()
-        return r.text
+        entries = r.json()
+        return next((e for e in entries if e.get("type") == 1), None)
 
     def _fetch_error(self):
-        data = {"serObject": f"err=1&serialnumber={self._serial_no}&device=1"}
-        r = self._session.post(
-            "https://www.freeair-connect.de/getErrorTextLong.php", data=data
+        r = self._session.get(
+            f"{_BASE_URL}/error.php",
+            params={"errId": self._fad.error_state},
         )
 
         if not r.ok:
             return
 
-        err = urllib.parse.parse_qs(r.text)
+        err = r.json()
         self._error_text = {
-            "en": err["en"][0],
-            "de": err["de"][0],
+            "en": err["en"]["long"],
+            "de": err["de"]["long"],
         }
 
     def _parse(self, encrypted_data, timestamp, version, version_fa100):
@@ -526,13 +529,9 @@ class Connect:
         if operation_mode == 0:
             operation_mode = 1
         data = {
-            "RB_CL": comfort_level,
-            "RB_OM": operation_mode,
-            "srn_button": f"{self._serial_no}-Test",
-            "lang_button": "en",
-            "serial_password": "",
+            "serialnumber": self._serial_no,
+            "CL": comfort_level,
+            "OM": operation_mode,
         }
-        r = self._session.post(
-            "https://www.freeair-connect.de/bf.php", data=data
-        )
+        r = self._session.post(f"{_BASE_URL}/button.php", data=data)
         r.raise_for_status()

--- a/custom_components/freeair_connect/__init__.py
+++ b/custom_components/freeair_connect/__init__.py
@@ -35,7 +35,8 @@ class BluHomeConnectServer:
             _LOGGER.warning("Could not find shell for serial number derived from %s", s_value)
             return web.Response()
         timestamp = datetime.now()
-        encrypted_data = base64.b64decode(b_value, altchars="-_")
+        # Device uses ';' as base64 padding instead of '='
+        encrypted_data = base64.b64decode(b_value.replace(";", "="), altchars="-_")
         version = self._extract_version(s_value)
         shell.parse(encrypted_data, timestamp, version, version)
         return web.Response()

--- a/custom_components/freeair_connect/__init__.py
+++ b/custom_components/freeair_connect/__init__.py
@@ -1,7 +1,9 @@
+import base64
 import logging
-from datetime import timedelta
+from datetime import datetime, timedelta
 
 import voluptuous as vol
+from aiohttp import web
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (ATTR_CONFIGURATION_URL, ATTR_HW_VERSION,
                                  ATTR_IDENTIFIERS, ATTR_MANUFACTURER,
@@ -10,13 +12,67 @@ from homeassistant.core import HomeAssistant, ServiceCall, callback
 from homeassistant.helpers.dispatcher import dispatcher_send
 from homeassistant.helpers.event import async_track_time_interval
 
-from .const import CONF_PASSWORD, CONF_SERIAL_NO, DOMAIN, UPDATE_SENSORS_SIGNAL
+from .const import CONF_PASSWORD, CONF_SERIAL_NO, CONF_SERVER_MODE, DOMAIN, UPDATE_SENSORS_SIGNAL
 from .FreeAir import Connect
 
 _LOGGER = logging.getLogger(__name__)
 
 
 PLATFORMS = ["sensor", "binary_sensor", "number", "select"]
+
+BLUHOME_CONNECT_PORT = 80
+
+
+class BluHomeConnectServer:
+    def __init__(self, hass: HomeAssistant):
+        self._hass = hass
+
+    async def blu_home_index(self, request):
+        s_value = request.rel_url.query["s"]
+        b_value = request.rel_url.query["b"]
+        shell = self._select_shell(s_value)
+        if not shell:
+            _LOGGER.warning("Could not find shell for serial number derived from %s", s_value)
+            return web.Response()
+        timestamp = datetime.now()
+        encrypted_data = base64.b64decode(b_value, altchars="-_")
+        version = self._extract_version(s_value)
+        shell.parse(encrypted_data, timestamp, version, version)
+        return web.Response()
+
+    async def blu_home_control(self, request):
+        s_value = request.rel_url.query["s"]
+        shell = self._select_shell(s_value)
+        comfort_level = 5
+        operation_mode = 1
+        if shell:
+            comfort_level = shell.comfort_level() or comfort_level
+            operation_mode = shell.operation_mode() or operation_mode
+        else:
+            _LOGGER.warning("Could not find shell for serial number derived from %s", s_value)
+        response = f"heart__beat11{comfort_level}{operation_mode}\n"
+        return web.Response(text=response)
+
+    def _extract_version(self, s):
+        return s.split("y")[1]
+
+    def _select_shell(self, s):
+        parts = s.split("y")
+        serial_no = parts[0].split("x")[2]
+        return self._hass.data.setdefault(DOMAIN, {}).get(serial_no)
+
+    async def start_server(self):
+        app = web.Application()
+        app.add_routes([web.get("/apps/data/blucontrol/", self.blu_home_index)])
+        app.add_routes([web.get("/apps/data/blucontrol/control/", self.blu_home_control)])
+        runner = web.AppRunner(app, access_log=None)
+        await runner.setup()
+        site = web.TCPSite(runner, port=BLUHOME_CONNECT_PORT)
+        try:
+            await site.start()
+            _LOGGER.info("Started HTTP server on port %s", BLUHOME_CONNECT_PORT)
+        except OSError as error:
+            _LOGGER.error("Failed to start HTTP server on port %d: %s", BLUHOME_CONNECT_PORT, error)
 
 
 async def async_setup(hass, config):
@@ -37,15 +93,21 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up component from a config entry, config_entry contains data from config entry database."""
     shells = hass.data.setdefault(DOMAIN, {})
 
-    # store shell object
     serial_no = entry.data[CONF_SERIAL_NO]
+    server_mode = entry.data.get(CONF_SERVER_MODE, False)
 
     shell = FreeAirConnectShell(
-        hass, serial_no=serial_no, password=entry.data[CONF_PASSWORD]
+        hass, serial_no=serial_no, password=entry.data[CONF_PASSWORD], server_mode=server_mode
     )
     shells[serial_no] = shell
 
-    await hass.async_add_executor_job(shell._fac.fetch)
+    if server_mode:
+        if not hass.data.get(f"{DOMAIN}_server_started"):
+            server = BluHomeConnectServer(hass)
+            await server.start_server()
+            hass.data[f"{DOMAIN}_server_started"] = True
+    else:
+        await hass.async_add_executor_job(shell._fac.fetch)
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
@@ -70,15 +132,17 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry):
 class FreeAirConnectShell:
     """Shell object for FreeAir Connect. Stored in hass.data."""
 
-    def __init__(self, hass: HomeAssistant, serial_no: str, password: str):
+    def __init__(self, hass: HomeAssistant, serial_no: str, password: str, server_mode: bool = False):
         """Initialize the instance."""
         self._hass = hass
         self._serial_no = serial_no
-        self._fac = Connect(serial_no=serial_no, password=password)
+        self._server_mode = server_mode
+        self._fac = Connect(serial_no=serial_no, password=password, server_mode=server_mode)
 
-        self._fetch_callback_listener = async_track_time_interval(
-            self._hass, self._fetch_callback, timedelta(minutes=10)
-        )
+        if not server_mode:
+            self._fetch_callback_listener = async_track_time_interval(
+                self._hass, self._fetch_callback, timedelta(minutes=10)
+            )
 
     @callback
     def _fetch_callback(self, *_):
@@ -87,6 +151,17 @@ class FreeAirConnectShell:
     def _fetch(self):
         self._fac.fetch()
         dispatcher_send(self._hass, UPDATE_SENSORS_SIGNAL)
+
+    def parse(self, encrypted_bytes, timestamp, version, version_fa100):
+        data = self._fac.parse(encrypted_bytes, timestamp, version, version_fa100)
+        dispatcher_send(self._hass, UPDATE_SENSORS_SIGNAL)
+        return data
+
+    def comfort_level(self):
+        return self._fac._comfort_level
+
+    def operation_mode(self):
+        return self._fac._operation_mode
 
     async def set_comfort_level(self, value):
         l = lambda: self._fac.set_comfort_level(value)

--- a/custom_components/freeair_connect/__init__.py
+++ b/custom_components/freeair_connect/__init__.py
@@ -94,7 +94,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     shells = hass.data.setdefault(DOMAIN, {})
 
     serial_no = entry.data[CONF_SERIAL_NO]
-    server_mode = entry.data.get(CONF_SERVER_MODE, False)
+    server_mode = entry.options.get(CONF_SERVER_MODE, entry.data.get(CONF_SERVER_MODE, False))
 
     shell = FreeAirConnectShell(
         hass, serial_no=serial_no, password=entry.data[CONF_PASSWORD], server_mode=server_mode

--- a/custom_components/freeair_connect/config_flow.py
+++ b/custom_components/freeair_connect/config_flow.py
@@ -8,6 +8,25 @@ from homeassistant import config_entries
 from .const import CONF_PASSWORD, CONF_SERIAL_NO, CONF_SERVER_MODE, DOMAIN
 
 
+class FreeAirOptionsFlowHandler(config_entries.OptionsFlow):
+    """Options flow to change settings after initial setup."""
+
+    async def async_step_init(self, user_input=None):
+        current_server_mode = self.config_entry.options.get(
+            CONF_SERVER_MODE,
+            self.config_entry.data.get(CONF_SERVER_MODE, False),
+        )
+        if user_input is not None:
+            return self.async_create_entry(title="", data=user_input)
+
+        return self.async_show_form(
+            step_id="init",
+            data_schema=vol.Schema(
+                {vol.Optional(CONF_SERVER_MODE, default=current_server_mode): bool}
+            ),
+        )
+
+
 class FreeAirConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  # type: ignore
     """Component config flow."""
 
@@ -15,6 +34,10 @@ class FreeAirConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  # type: igno
 
     def __init__(self):
         self._source_name = None
+
+    @staticmethod
+    def async_get_options_flow(config_entry):
+        return FreeAirOptionsFlowHandler(config_entry)
 
     async def async_step_user(self, user_input=None):
         """Handle the start of the config flow.

--- a/custom_components/freeair_connect/config_flow.py
+++ b/custom_components/freeair_connect/config_flow.py
@@ -5,7 +5,7 @@ Used by UI to setup integration.
 import voluptuous as vol
 from homeassistant import config_entries
 
-from .const import CONF_PASSWORD, CONF_SERIAL_NO, DOMAIN
+from .const import CONF_PASSWORD, CONF_SERIAL_NO, CONF_SERVER_MODE, DOMAIN
 
 
 class FreeAirConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  # type: ignore
@@ -27,7 +27,11 @@ class FreeAirConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  # type: igno
         """
         if user_input is None:
             data_schema = vol.Schema(
-                {vol.Required(CONF_SERIAL_NO): str, vol.Required(CONF_PASSWORD): str},
+                {
+                    vol.Required(CONF_SERIAL_NO): str,
+                    vol.Required(CONF_PASSWORD): str,
+                    vol.Optional(CONF_SERVER_MODE, default=False): bool,
+                },
             )
             return self.async_show_form(step_id="user", data_schema=data_schema)
 
@@ -41,5 +45,9 @@ class FreeAirConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  # type: igno
         title = f"FreeAir S/N: {serial_no}"
         return self.async_create_entry(
             title=title,
-            data={CONF_SERIAL_NO: serial_no, CONF_PASSWORD: user_input[CONF_PASSWORD]},
+            data={
+                CONF_SERIAL_NO: serial_no,
+                CONF_PASSWORD: user_input[CONF_PASSWORD],
+                CONF_SERVER_MODE: user_input.get(CONF_SERVER_MODE, False),
+            },
         )

--- a/custom_components/freeair_connect/config_flow.py
+++ b/custom_components/freeair_connect/config_flow.py
@@ -37,7 +37,7 @@ class FreeAirConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  # type: igno
 
     @staticmethod
     def async_get_options_flow(config_entry):
-        return FreeAirOptionsFlowHandler(config_entry)
+        return FreeAirOptionsFlowHandler()
 
     async def async_step_user(self, user_input=None):
         """Handle the start of the config flow.

--- a/custom_components/freeair_connect/const.py
+++ b/custom_components/freeair_connect/const.py
@@ -5,6 +5,7 @@ DOMAIN = "freeair_connect"
 
 CONF_SERIAL_NO = "serial_no"
 CONF_PASSWORD = "password"
+CONF_SERVER_MODE = "server_mode"
 
 UPDATE_SENSORS_SIGNAL = f"{DOMAIN}_update_sensors_signal"
 

--- a/custom_components/freeair_connect/swagger.yml
+++ b/custom_components/freeair_connect/swagger.yml
@@ -1,0 +1,306 @@
+openapi: 3.0.4
+info:
+  title: freeair-connect api
+  version: '1.0.0'
+
+servers:
+  - url: https://freeair-connect.de/
+    description: main server
+
+paths:
+  /api/login.php:
+    post:
+      summary: Authenticate with a device password, or check existing session
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              required:
+                - serialnumber
+              properties:
+                serialnumber:
+                  type: integer
+                  example: 52001
+                  description: Numeric serial number of the device (max 6 digits)
+                serial_password:
+                  type: string
+                  example: freeAir
+                  description: Device password. Omit to check existing session only.
+                lang:
+                  type: string
+                  example: de
+                  description: Language code (e.g. "de", "en"). Stored in session.
+      responses:
+        "200":
+          description: Login response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/loginResponse'
+        "400":
+          description: Bad request (invalid serialnumber)
+        "405":
+          description: Method not allowed
+
+  /api/logout.php:
+    post:
+      summary: Log out a device from the session
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              required:
+                - serialnumber
+              properties:
+                serialnumber:
+                  type: integer
+                  example: 52001
+                  description: Numeric serial number of the device (max 6 digits)
+      responses:
+        "200":
+          description: Logout successful
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    example: true
+        "400":
+          description: Bad request (invalid serialnumber)
+        "405":
+          description: Method not allowed
+
+  /api/values.php:
+    get:
+      summary: Returns the primary and secondary logs for a device
+      parameters:
+        - in: query
+          name: serialnumber
+          required: true
+          schema:
+            type: integer
+          description: Numeric serial number of the device
+      responses:
+        "200":
+          description: >
+            A JSON array of log values. The first element is the latest primary log (type 1).
+            Remaining elements are day logs (type 2) or month logs (type 3). The log data is encrypted.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/value'
+        "400":
+          description: Bad request (invalid serialnumber)
+        "401":
+          description: Unauthorized (not logged in for this device)
+
+  /api/error.php:
+    get:
+      summary: Returns error type details by ID
+      parameters:
+        - in: query
+          name: errId
+          required: true
+          schema:
+            type: integer
+          description: Numeric ID of the error type
+      responses:
+        "200":
+          description: Error type details in German and English
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  id_error_type:
+                    type: integer
+                    example: 5
+                  en:
+                    $ref: '#/components/schemas/errorinfo'
+                  de:
+                    $ref: '#/components/schemas/errorinfo'
+        "400":
+          description: Bad request (invalid errId)
+        "404":
+          description: Error type not found
+
+  /api/user-info.php:
+    post:
+      summary: Update the device name and notification email address
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              required:
+                - serialnumber
+                - pw
+              properties:
+                serialnumber:
+                  type: integer
+                  example: 52001
+                  description: Numeric serial number of the device (max 6 digits)
+                pw:
+                  type: string
+                  example: freeAir
+                  description: Device password (4–16 characters), used to re-validate the request
+                name:
+                  type: string
+                  example: "Wohnung Muster"
+                  description: Display name for the device
+                ea1:
+                  type: string
+                  format: email
+                  example: "user@example.com"
+                  description: Email address for error notifications (max 50 characters)
+      responses:
+        "200":
+          description: Update successful
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    example: true
+        "400":
+          description: Bad request (invalid input)
+        "401":
+          description: Unauthorized (not logged in or wrong password)
+        "404":
+          description: No log data found for device
+        "405":
+          description: Method not allowed
+
+  /api/button.php:
+    post:
+      summary: Set comfort level and operating mode on a device
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/buttonData'
+      responses:
+        "200":
+          description: Button command stored successfully
+        "400":
+          description: Bad request (invalid parameters)
+        "401":
+          description: Unauthorized (wrong password)
+        "404":
+          description: No log data found for device
+        "405":
+          description: Method not allowed
+
+  /api/language.php:
+    get:
+      deprecated: true
+      summary: Returns translation strings
+      parameters:
+        - in: query
+          name: lang
+          schema:
+            type: string
+      responses:
+        "200":
+          description: A JSON object of language strings
+
+  /api/secLogTranslations.php:
+    get:
+      deprecated: true
+      summary: Returns secondary log translations
+      responses:
+        "200":
+          description: Secondary log translation strings
+
+components:
+  schemas:
+    loginResponse:
+      type: object
+      properties:
+        showLogout:
+          type: boolean
+          description: Whether the logout button should be shown (i.e. login was successful)
+          example: true
+        serverMessage:
+          type: string
+          description: Localised message to display to the user (empty on success)
+          example: ""
+        inputActive:
+          type: boolean
+          description: Whether the password input should remain active
+          example: true
+        deviceName:
+          type: string
+          description: Device name from the database
+          example: "Wohnung Muster"
+
+    buttonData:
+      type: object
+      required:
+        - serialnumber
+      properties:
+        serialnumber:
+          type: integer
+          example: 50000
+          description: Serial number of the device
+        CL:
+          type: integer
+          example: 2
+          description: Comfort level to set
+        OM:
+          type: integer
+          example: 1
+          description: Operating mode to set
+
+    value:
+      type: object
+      properties:
+        log:
+          type: string
+          example: "ABCABCABCABCABCABCABCABC"
+          description: Encrypted log blob from the device
+        timestamp:
+          type: string
+          example: "2026-02-17 09:06:53"
+        type:
+          type: integer
+          example: 1
+          description: "1 = primary log, 2 = secondary day log, 3 = secondary month log"
+        versionCC3200:
+          type: string
+          example: "2x24x0"
+        versionMain:
+          type: string
+          example: "2x24x0"
+
+    errorinfo:
+      type: object
+      properties:
+        short:
+          type: string
+          example: "Err-FiDI"
+          description: Short error code for display in a table
+        long:
+          type: string
+          example: "This is a long description of the error"
+          description: "Error message body — displayed as: pre + long + part2"
+        part2:
+          type: string
+          example: "(Gerät hat ausgeschaltet)"
+          description: "Error message suffix — displayed as: pre + long + part2"
+        pre:
+          type: string
+          example: "Error:"
+          description: "Error message prefix — displayed as: pre + long + part2"

--- a/custom_components/freeair_connect/translations/de.json
+++ b/custom_components/freeair_connect/translations/de.json
@@ -1,4 +1,14 @@
 {
+    "options": {
+      "step": {
+        "init": {
+          "description": "Im lokalen Server-Modus sendet das Gerät Daten direkt an Home Assistant (Port 80). Dazu muss die IP-Adresse von Home Assistant in der FreeAir USB-App am Gerät eingestellt werden.",
+          "data": {
+            "server_mode": "Lokalen Server aktivieren (Port 80)"
+          }
+        }
+      }
+    },
     "config": {
       "abort": {
         "already_configured": "Dieses Gerät ist bereits eingerichtet.",
@@ -6,10 +16,11 @@
       },
       "step": {
         "user": {
+          "description": "Im lokalen Server-Modus sendet das Gerät Daten direkt an Home Assistant (Port 80). Dazu muss die IP-Adresse von Home Assistant in der FreeAir USB-App am Gerät eingestellt werden.",
           "data": {
             "serial_no": "Seriennummer",
             "password": "Passwort",
-            "server_mode": "Lokalen Server aktivieren (Gerät sendet Daten direkt, Port 80)"
+            "server_mode": "Lokalen Server aktivieren (Port 80)"
           }
         }
       }

--- a/custom_components/freeair_connect/translations/de.json
+++ b/custom_components/freeair_connect/translations/de.json
@@ -8,7 +8,8 @@
         "user": {
           "data": {
             "serial_no": "Seriennummer",
-            "password": "Passwort"
+            "password": "Passwort",
+            "server_mode": "Lokalen Server aktivieren (Gerät sendet Daten direkt, Port 80)"
           }
         }
       }

--- a/custom_components/freeair_connect/translations/en.json
+++ b/custom_components/freeair_connect/translations/en.json
@@ -8,7 +8,8 @@
         "user": {
           "data": {
             "serial_no": "Serial Number",
-            "password": "Password"
+            "password": "Password",
+            "server_mode": "Enable local server (device pushes data directly, port 80)"
           }
         }
       }

--- a/custom_components/freeair_connect/translations/en.json
+++ b/custom_components/freeair_connect/translations/en.json
@@ -1,4 +1,14 @@
 {
+    "options": {
+      "step": {
+        "init": {
+          "description": "In local server mode, the device sends data directly to Home Assistant (port 80). You need to configure the IP address of your Home Assistant instance in the FreeAir USB app on the device.",
+          "data": {
+            "server_mode": "Enable local server (port 80)"
+          }
+        }
+      }
+    },
     "config": {
       "abort": {
         "already_configured": "This market area is already configured.",
@@ -6,10 +16,11 @@
       },
       "step": {
         "user": {
+          "description": "In local server mode, the device sends data directly to Home Assistant (port 80). You need to configure the IP address of your Home Assistant instance in the FreeAir USB app on the device.",
           "data": {
             "serial_no": "Serial Number",
             "password": "Password",
-            "server_mode": "Enable local server (device pushes data directly, port 80)"
+            "server_mode": "Enable local server (port 80)"
           }
         }
       }


### PR DESCRIPTION
Hi,
we had to rework the api at freeair-connect.de.
the deprecated api endpoints are now gone.
I released the changes today to the webapp freeair-connect.de.

I changed the home assistant integration to work with the new api.

I will also try to merge the changes from https://github.com/BenRomberg/ha_freeair_connect according to https://github.com/mampfes/ha_freeair_connect/issues/21