### PR TITLE
Merge bluhome (local server) and freeair api (client mode)

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,15 @@ In case you would like to install manually:
 
 This component provides sensors for all major values provided by a FreeAir device.
 
+## Local Server Mode
+
+Instead of polling the freeair-connect.de cloud, the integration can run a local HTTP server that receives data directly from the device. To use this mode:
+
+1. Enable **"Lokalen Server aktivieren"** / **"Enable local server"** during setup, or afterwards via **Settings → Integrations → FreeAir Connect → Configure**.
+2. Using the FreeAir USB app, configure the device's server address to the IP address of your Home Assistant instance.
+
+> **Note:** The local server listens on port 80. Make sure this port is not already in use on your Home Assistant host.
+
 ## Refresh Service
 
 If you want to trigger a manual refresh of all device data, you can call the service:

--- a/custom_components/freeair_connect/FreeAir/__init__.py
+++ b/custom_components/freeair_connect/FreeAir/__init__.py
@@ -5,9 +5,9 @@ from datetime import datetime
 
 import requests
 from py3rijndael import RijndaelCbc, ZeroPadding
+from aiohttp import web
 
 _LOGGER = logging.getLogger(__name__)
-
 
 class _BitSlice:
     def __init__(self, bytepos, bitoffset, length):
@@ -414,6 +414,8 @@ class Connect:
         self._error_text = {}
         self._session = requests.Session()
         self._session.headers.update(_DEFAULT_HEADERS)
+        self._comfort_level = None
+        self._operation_mode = None
 
     @property
     def fetchtime(self):
@@ -439,32 +441,7 @@ class Connect:
             raise Exception(f"Login failed: {response.get('serverMessage', 'unknown error')}")
 
     def fetch(self):
-        entry = None
-        try:
-            self._login()
-            entry = self._fetch_data()
-        except Exception as error:
-            self._fad = None
-            self._error_text = {}
-            _LOGGER.error(f"fetch failed for SN {self._serial_no}: {error}")
-            return
-
-        if entry is None:
-            _LOGGER.error(f"No data received for SN {self._serial_no}")
-            return
-
-        encrypted_data = entry["log"]
-        timestamp = datetime.strptime(entry["timestamp"], "%Y-%m-%d %H:%M:%S")
-        version = entry["versionCC3200"]
-        version_fa100 = entry["versionMain"]
-
-        self._fad = self._parse(encrypted_data, timestamp, version, version_fa100)
-        self._fetchtime = timestamp
-
-        if self._fad.error_state not in (0, 22):
-            self._fetch_error()
-        else:
-            self._error_text = {}
+        _LOGGER.info(f"No longer fetching data from freeair-connect.de")
 
     def _fetch_data(self):
         r = self._session.get(
@@ -476,9 +453,10 @@ class Connect:
         return next((e for e in entries if e.get("type") == 1), None)
 
     def _fetch_error(self):
-        r = self._session.get(
-            f"{_BASE_URL}/error.php",
-            params={"errId": self._fad.error_state},
+        self._login()
+        data = {"serObject": f"err=1&serialnumber={self._serial_no}&device=1"}
+        r = self._session.post(
+            "https://www.freeair-connect.de/getErrorTextLong.php", data=data
         )
 
         if not r.ok:
@@ -490,22 +468,24 @@ class Connect:
             "de": err["de"]["long"],
         }
 
-    def _parse(self, encrypted_data, timestamp, version, version_fa100):
-        encrypted_data = base64.b64decode(encrypted_data)
+    def parse(self, encrypted_data, timestamp, version, version_fa100):
+        # encrypted_data = "PgiFboacxLklQ3gz8APQ87wwROYqCWCKViRZR0XCZo72CrWG3Cn91Dr+it7SfJwD"
+        # encrypted_data = urllib.parse.unquote(encrypted_data) # this is probably not needed!
+        # encrypted_data = base64.b64decode(encrypted_data)
 
-        version_numbers = version.split("x")
-        major = int(version_numbers[0])
-        minor = int(version_numbers[1])
-        if major == 2 and (minor <= 13 or minor == 20 or minor == 21):
-            iv = "000102030405060708090a0b0c0d0e0f"
-            size = 16
-        else:
-            iv = "30313233343536373839303132333435"
-            size = 32
+#        version_numbers = version.split("x")
+#        major = int(version_numbers[0])
+#        minor = int(version_numbers[1])
+#        if major == 2 and (minor <= 13 or minor == 20 or minor == 21):
+        iv = "000102030405060708090a0b0c0d0e0f"
+        size = 16
+#        else:
+#            iv = "30313233343536373839303132333435"
+#            size = 32
 
         # prepare initialization vector
         iv = binascii.unhexlify(iv)
-        
+
         # fill password to 16 characters with zeros
         pw = self._password.ljust(size, "0")
 
@@ -513,25 +493,37 @@ class Connect:
         data = rijndael.decrypt(encrypted_data)
 
         # extract data
-        return Data(data, timestamp, version, version_fa100)
+        self._fad = Data(data, timestamp, version, version_fa100)
+
+        if self._fad.error_state not in (0, 22):
+            # fetch error string
+            self._fetch_error()
+        else:
+            self._error_text = {}
+
+        if self._comfort_level is None:
+            self._comfort_level = self._fad.comfort_level
+        self._fad.set_comfort_level(self._comfort_level)
+
+        if self._operation_mode is None:
+            self._operation_mode = self._fad.operation_mode
+        self._fad.set_operation_mode(self._operation_mode)
+
+        return self._fad
 
     def set_comfort_level(self, value):
         assert value >= 1 and value <= 5
-        self._fad.set_comfort_level(value)
-        self.set_cl_and_om(value, self._fad.operation_mode)
+        self.set_cl_and_om(value, self._operation_mode)
 
     def set_operation_mode(self, value):
         assert value >= 1 and value <= 4
-        self._fad.set_operation_mode(value)
-        self.set_cl_and_om(self._fad.comfort_level, value)
+        self.set_cl_and_om(self._comfort_level, value)
 
     def set_cl_and_om(self, comfort_level, operation_mode):
         if operation_mode == 0:
             operation_mode = 1
-        data = {
-            "serialnumber": self._serial_no,
-            "CL": comfort_level,
-            "OM": operation_mode,
-        }
-        r = self._session.post(f"{_BASE_URL}/button.php", data=data)
-        r.raise_for_status()
+        self._comfort_level = comfort_level
+        self._operation_mode = operation_mode
+        self._fad.set_comfort_level(self._comfort_level)
+        self._fad.set_operation_mode(self._operation_mode)
+        _LOGGER.info(f"Setting comfort_level to {self._comfort_level}, operation_mode to {self._operation_mode}")

--- a/custom_components/freeair_connect/FreeAir/__init__.py
+++ b/custom_components/freeair_connect/FreeAir/__init__.py
@@ -5,9 +5,9 @@ from datetime import datetime
 
 import requests
 from py3rijndael import RijndaelCbc, ZeroPadding
-from aiohttp import web
 
 _LOGGER = logging.getLogger(__name__)
+
 
 class _BitSlice:
     def __init__(self, bytepos, bitoffset, length):
@@ -306,9 +306,17 @@ class Data:
         return self._extract([_BitSlice(34, 4, 1), _BitSlice(21, 0, 7)])
 
     @property
+    def _is_crypt256(self):
+        parts = self._version.split("x")
+        major = int(parts[0])
+        minor = int(parts[1])
+        return not (major == 2 and (minor <= 13 or minor == 20 or minor == 21))
+
+    @property
     def rssi(self):
-        val = self._extract([_BitSlice(47, 0, 8)])
-        return self._as_signed(val, 8)
+        # AES-256 firmware stores RSSI at byte 43; AES-128 at byte 47
+        byte_pos = 43 if self._is_crypt256 else 47
+        return self._as_signed(self._data[byte_pos], 8)
 
     @property
     def filter_status_supply(self):
@@ -406,9 +414,10 @@ _DEFAULT_HEADERS = {
 
 
 class Connect:
-    def __init__(self, serial_no, password):
+    def __init__(self, serial_no, password, server_mode=False):
         self._serial_no = serial_no
         self._password = password
+        self._server_mode = server_mode
         self._fetchtime = None
         self._fad = None
         self._error_text = {}
@@ -441,7 +450,32 @@ class Connect:
             raise Exception(f"Login failed: {response.get('serverMessage', 'unknown error')}")
 
     def fetch(self):
-        _LOGGER.info(f"No longer fetching data from freeair-connect.de")
+        entry = None
+        try:
+            self._login()
+            entry = self._fetch_data()
+        except Exception as error:
+            self._fad = None
+            self._error_text = {}
+            _LOGGER.error(f"fetch failed for SN {self._serial_no}: {error}")
+            return
+
+        if entry is None:
+            _LOGGER.error(f"No data received for SN {self._serial_no}")
+            return
+
+        encrypted_data = entry["log"]
+        timestamp = datetime.strptime(entry["timestamp"], "%Y-%m-%d %H:%M:%S")
+        version = entry["versionCC3200"]
+        version_fa100 = entry["versionMain"]
+
+        self._fad = self._parse(encrypted_data, timestamp, version, version_fa100)
+        self._fetchtime = timestamp
+
+        if self._fad.error_state not in (0, 22):
+            self._fetch_error()
+        else:
+            self._error_text = {}
 
     def _fetch_data(self):
         r = self._session.get(
@@ -453,10 +487,9 @@ class Connect:
         return next((e for e in entries if e.get("type") == 1), None)
 
     def _fetch_error(self):
-        self._login()
-        data = {"serObject": f"err=1&serialnumber={self._serial_no}&device=1"}
-        r = self._session.post(
-            "https://www.freeair-connect.de/getErrorTextLong.php", data=data
+        r = self._session.get(
+            f"{_BASE_URL}/error.php",
+            params={"errId": self._fad.error_state},
         )
 
         if not r.ok:
@@ -468,36 +501,17 @@ class Connect:
             "de": err["de"]["long"],
         }
 
-    def parse(self, encrypted_data, timestamp, version, version_fa100):
-        # encrypted_data = "PgiFboacxLklQ3gz8APQ87wwROYqCWCKViRZR0XCZo72CrWG3Cn91Dr+it7SfJwD"
-        # encrypted_data = urllib.parse.unquote(encrypted_data) # this is probably not needed!
-        # encrypted_data = base64.b64decode(encrypted_data)
-
-#        version_numbers = version.split("x")
-#        major = int(version_numbers[0])
-#        minor = int(version_numbers[1])
-#        if major == 2 and (minor <= 13 or minor == 20 or minor == 21):
-        iv = "000102030405060708090a0b0c0d0e0f"
-        size = 16
-#        else:
-#            iv = "30313233343536373839303132333435"
-#            size = 32
-
-        # prepare initialization vector
-        iv = binascii.unhexlify(iv)
-
-        # fill password to 16 characters with zeros
-        pw = self._password.ljust(size, "0")
-
-        rijndael = RijndaelCbc(key=pw, iv=iv, padding=ZeroPadding(16), block_size=16)
-        data = rijndael.decrypt(encrypted_data)
-
-        # extract data
-        self._fad = Data(data, timestamp, version, version_fa100)
+    def parse(self, encrypted_bytes, timestamp, version, version_fa100):
+        """Decrypt and parse raw bytes pushed by the device (server mode)."""
+        # Server mode always uses AES-128 regardless of firmware version
+        self._fad = self._decrypt_aes128(encrypted_bytes, timestamp, version, version_fa100)
+        self._fetchtime = timestamp
 
         if self._fad.error_state not in (0, 22):
-            # fetch error string
-            self._fetch_error()
+            try:
+                self._fetch_error()
+            except Exception:
+                pass
         else:
             self._error_text = {}
 
@@ -511,19 +525,56 @@ class Connect:
 
         return self._fad
 
+    def _parse(self, encrypted_data, timestamp, version, version_fa100):
+        return self._decrypt(base64.b64decode(encrypted_data), timestamp, version, version_fa100)
+
+    def _decrypt_aes128(self, encrypted_bytes, timestamp, version, version_fa100):
+        iv = binascii.unhexlify("000102030405060708090a0b0c0d0e0f")
+        pw = self._password.ljust(16, "0")
+        rijndael = RijndaelCbc(key=pw, iv=iv, padding=ZeroPadding(16), block_size=16)
+        data = rijndael.decrypt(encrypted_bytes)
+        return Data(data, timestamp, version, version_fa100)
+
+    def _decrypt(self, encrypted_bytes, timestamp, version, version_fa100):
+        version_numbers = version.split("x")
+        major = int(version_numbers[0])
+        minor = int(version_numbers[1])
+        if major == 2 and (minor <= 13 or minor == 20 or minor == 21):
+            iv = "000102030405060708090a0b0c0d0e0f"
+            size = 16
+        else:
+            iv = "30313233343536373839303132333435"
+            size = 32
+
+        iv = binascii.unhexlify(iv)
+        pw = self._password.ljust(size, "0")
+
+        rijndael = RijndaelCbc(key=pw, iv=iv, padding=ZeroPadding(16), block_size=16)
+        data = rijndael.decrypt(encrypted_bytes)
+
+        return Data(data, timestamp, version, version_fa100)
+
     def set_comfort_level(self, value):
         assert value >= 1 and value <= 5
-        self.set_cl_and_om(value, self._operation_mode)
+        self.set_cl_and_om(value, self._operation_mode or self._fad.operation_mode)
 
     def set_operation_mode(self, value):
         assert value >= 1 and value <= 4
-        self.set_cl_and_om(self._comfort_level, value)
+        self.set_cl_and_om(self._comfort_level or self._fad.comfort_level, value)
 
     def set_cl_and_om(self, comfort_level, operation_mode):
         if operation_mode == 0:
             operation_mode = 1
         self._comfort_level = comfort_level
         self._operation_mode = operation_mode
-        self._fad.set_comfort_level(self._comfort_level)
-        self._fad.set_operation_mode(self._operation_mode)
-        _LOGGER.info(f"Setting comfort_level to {self._comfort_level}, operation_mode to {self._operation_mode}")
+        if self._fad:
+            self._fad.set_comfort_level(comfort_level)
+            self._fad.set_operation_mode(operation_mode)
+        if not self._server_mode:
+            data = {
+                "serialnumber": self._serial_no,
+                "CL": comfort_level,
+                "OM": operation_mode,
+            }
+            r = self._session.post(f"{_BASE_URL}/button.php", data=data)
+            r.raise_for_status()

--- a/custom_components/freeair_connect/__init__.py
+++ b/custom_components/freeair_connect/__init__.py
@@ -1,7 +1,9 @@
+import base64
 import logging
-from datetime import timedelta
+from datetime import datetime, timedelta
 
 import voluptuous as vol
+from aiohttp import web
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (ATTR_CONFIGURATION_URL, ATTR_HW_VERSION,
                                  ATTR_IDENTIFIERS, ATTR_MANUFACTURER,
@@ -10,11 +12,8 @@ from homeassistant.core import HomeAssistant, ServiceCall, callback
 from homeassistant.helpers.dispatcher import dispatcher_send
 from homeassistant.helpers.event import async_track_time_interval
 
-from .const import CONF_PASSWORD, CONF_SERIAL_NO, DOMAIN, UPDATE_SENSORS_SIGNAL
+from .const import CONF_PASSWORD, CONF_SERIAL_NO, CONF_SERVER_MODE, DOMAIN, UPDATE_SENSORS_SIGNAL
 from .FreeAir import Connect
-from aiohttp import web
-from datetime import datetime
-import base64
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -23,27 +22,27 @@ PLATFORMS = ["sensor", "binary_sensor", "number", "select"]
 
 BLUHOME_CONNECT_PORT = 80
 
+
 class BluHomeConnectServer:
     def __init__(self, hass: HomeAssistant):
         self._hass = hass
 
     async def blu_home_index(self, request):
-        s_value = request.rel_url.query['s']
-        b_value = request.rel_url.query['b']
-        _LOGGER.info(f"Received index request with s = {s_value}, b = {b_value}")
+        s_value = request.rel_url.query["s"]
+        b_value = request.rel_url.query["b"]
         shell = self._select_shell(s_value)
         if not shell:
-            _LOGGER.warn(f"Could not find shell for serial number {s_value}")
+            _LOGGER.warning("Could not find shell for serial number derived from %s", s_value)
             return web.Response()
         timestamp = datetime.now()
-        encrypted_data = base64.b64decode(b_value, altchars="-_")
+        # Device uses ';' as base64 padding instead of '='
+        encrypted_data = base64.b64decode(b_value.replace(";", "="), altchars="-_")
         version = self._extract_version(s_value)
-        data = shell.parse(encrypted_data, timestamp, version, version)
-        _LOGGER.info(f"Interpreted data for serial number {shell.serial_no}: temp_supply = {data.temp_supply}, temp_outdoor = {data.temp_outdoor}, temp_extract = {data.temp_extract}, temp_exhaust = {data.temp_exhaust}, humidity_outdoor_rel = {data.humidity_outdoor_rel}, humidity_extract_rel = {data.humidity_extract_rel}, co2_extract = {data.co2_extract}, comfort_level = {data.comfort_level}, operation_mode = {data.operation_mode}, air_flow = {data.air_flow}, filter_hours = {data.filter_hours}")
+        shell.parse(encrypted_data, timestamp, version, version)
         return web.Response()
 
     async def blu_home_control(self, request):
-        s_value = request.rel_url.query['s']
+        s_value = request.rel_url.query["s"]
         shell = self._select_shell(s_value)
         comfort_level = 5
         operation_mode = 1
@@ -51,42 +50,33 @@ class BluHomeConnectServer:
             comfort_level = shell.comfort_level() or comfort_level
             operation_mode = shell.operation_mode() or operation_mode
         else:
-            _LOGGER.warn(f"Could not find shell for serial number {s_value}")
+            _LOGGER.warning("Could not find shell for serial number derived from %s", s_value)
         response = f"heart__beat11{comfort_level}{operation_mode}\n"
-        _LOGGER.info(f"Received control request with s = {s_value}, b = {request.rel_url.query['b']}, response was {response}")
-        return web.Response(text = response)
+        return web.Response(text=response)
 
     def _extract_version(self, s):
-        # s = '1x1x57225y2x22x0'
-        parts = s.split('y')
-        return parts[1]
+        return s.split("y")[1]
 
     def _select_shell(self, s):
-        # s = '1x1x57225y2x22x0'
-        parts = s.split('y')
-        serial_parts = parts[0].split('x')
-        serial_no = serial_parts[2]
-        shells = self._hass.data.setdefault(DOMAIN, {})
-        return shells[serial_no]
+        parts = s.split("y")
+        serial_no = parts[0].split("x")[2]
+        return self._hass.data.setdefault(DOMAIN, {}).get(serial_no)
 
     async def start_server(self):
         app = web.Application()
-        app.add_routes([web.get('/apps/data/blucontrol/', self.blu_home_index)])
-        app.add_routes([web.get('/apps/data/blucontrol/control/', self.blu_home_control)])
+        app.add_routes([web.get("/apps/data/blucontrol/", self.blu_home_index)])
+        app.add_routes([web.get("/apps/data/blucontrol/control/", self.blu_home_control)])
         runner = web.AppRunner(app, access_log=None)
         await runner.setup()
-        http_site = web.TCPSite(runner, port=BLUHOME_CONNECT_PORT)
+        site = web.TCPSite(runner, port=BLUHOME_CONNECT_PORT)
         try:
-            await http_site.start()
-            _LOGGER.info("Started HTTP webserver on port %s", BLUHOME_CONNECT_PORT)
+            await site.start()
+            _LOGGER.info("Started HTTP server on port %s", BLUHOME_CONNECT_PORT)
         except OSError as error:
-            _LOGGER.error("Failed to create HTTP server at port %d: %s", BLUHOME_CONNECT_PORT, error)
+            _LOGGER.error("Failed to start HTTP server on port %d: %s", BLUHOME_CONNECT_PORT, error)
 
 
 async def async_setup(hass, config):
-    blu_home = BluHomeConnectServer(hass)
-    await blu_home.start_server()
-
     async def async_fetch_data(service: ServiceCall) -> None:
         shells = hass.data.setdefault(DOMAIN, {})
 
@@ -104,15 +94,21 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up component from a config entry, config_entry contains data from config entry database."""
     shells = hass.data.setdefault(DOMAIN, {})
 
-    # store shell object
     serial_no = entry.data[CONF_SERIAL_NO]
+    server_mode = entry.options.get(CONF_SERVER_MODE, entry.data.get(CONF_SERVER_MODE, False))
 
     shell = FreeAirConnectShell(
-        hass, serial_no=serial_no, password=entry.data[CONF_PASSWORD]
+        hass, serial_no=serial_no, password=entry.data[CONF_PASSWORD], server_mode=server_mode
     )
     shells[serial_no] = shell
 
-    await hass.async_add_executor_job(shell._fac.fetch)
+    if server_mode:
+        if not hass.data.get(f"{DOMAIN}_server_started"):
+            server = BluHomeConnectServer(hass)
+            await server.start_server()
+            hass.data[f"{DOMAIN}_server_started"] = True
+    else:
+        await hass.async_add_executor_job(shell._fac.fetch)
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
@@ -137,15 +133,17 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry):
 class FreeAirConnectShell:
     """Shell object for FreeAir Connect. Stored in hass.data."""
 
-    def __init__(self, hass: HomeAssistant, serial_no: str, password: str):
+    def __init__(self, hass: HomeAssistant, serial_no: str, password: str, server_mode: bool = False):
         """Initialize the instance."""
         self._hass = hass
         self._serial_no = serial_no
-        self._fac = Connect(serial_no=serial_no, password=password)
+        self._server_mode = server_mode
+        self._fac = Connect(serial_no=serial_no, password=password, server_mode=server_mode)
 
-        self._fetch_callback_listener = async_track_time_interval(
-            self._hass, self._fetch_callback, timedelta(minutes=10)
-        )
+        if not server_mode:
+            self._fetch_callback_listener = async_track_time_interval(
+                self._hass, self._fetch_callback, timedelta(minutes=10)
+            )
 
     @callback
     def _fetch_callback(self, *_):
@@ -153,12 +151,18 @@ class FreeAirConnectShell:
 
     def _fetch(self):
         self._fac.fetch()
-#        dispatcher_send(self._hass, UPDATE_SENSORS_SIGNAL)
+        dispatcher_send(self._hass, UPDATE_SENSORS_SIGNAL)
 
-    def parse(self, encrypted_data, timestamp, version, version_fa100):
-        data = self._fac.parse(encrypted_data, timestamp, version, version_fa100)
+    def parse(self, encrypted_bytes, timestamp, version, version_fa100):
+        data = self._fac.parse(encrypted_bytes, timestamp, version, version_fa100)
         dispatcher_send(self._hass, UPDATE_SENSORS_SIGNAL)
         return data
+
+    def comfort_level(self):
+        return self._fac._comfort_level
+
+    def operation_mode(self):
+        return self._fac._operation_mode
 
     async def set_comfort_level(self, value):
         l = lambda: self._fac.set_comfort_level(value)
@@ -167,12 +171,6 @@ class FreeAirConnectShell:
     async def set_operation_mode(self, value):
         l = lambda: self._fac.set_operation_mode(value)
         await self._hass.async_add_executor_job(l)
-
-    def operation_mode(self):
-        return self._fac._operation_mode
-
-    def comfort_level(self):
-        return self._fac._comfort_level
 
     @property
     def serial_no(self):

--- a/custom_components/freeair_connect/__init__.py
+++ b/custom_components/freeair_connect/__init__.py
@@ -12,14 +12,81 @@ from homeassistant.helpers.event import async_track_time_interval
 
 from .const import CONF_PASSWORD, CONF_SERIAL_NO, DOMAIN, UPDATE_SENSORS_SIGNAL
 from .FreeAir import Connect
+from aiohttp import web
+from datetime import datetime
+import base64
 
 _LOGGER = logging.getLogger(__name__)
 
 
 PLATFORMS = ["sensor", "binary_sensor", "number", "select"]
 
+BLUHOME_CONNECT_PORT = 80
+
+class BluHomeConnectServer:
+    def __init__(self, hass: HomeAssistant):
+        self._hass = hass
+
+    async def blu_home_index(self, request):
+        s_value = request.rel_url.query['s']
+        b_value = request.rel_url.query['b']
+        _LOGGER.info(f"Received index request with s = {s_value}, b = {b_value}")
+        shell = self._select_shell(s_value)
+        if not shell:
+            _LOGGER.warn(f"Could not find shell for serial number {s_value}")
+            return web.Response()
+        timestamp = datetime.now()
+        encrypted_data = base64.b64decode(b_value, altchars="-_")
+        version = self._extract_version(s_value)
+        data = shell.parse(encrypted_data, timestamp, version, version)
+        _LOGGER.info(f"Interpreted data for serial number {shell.serial_no}: temp_supply = {data.temp_supply}, temp_outdoor = {data.temp_outdoor}, temp_extract = {data.temp_extract}, temp_exhaust = {data.temp_exhaust}, humidity_outdoor_rel = {data.humidity_outdoor_rel}, humidity_extract_rel = {data.humidity_extract_rel}, co2_extract = {data.co2_extract}, comfort_level = {data.comfort_level}, operation_mode = {data.operation_mode}, air_flow = {data.air_flow}, filter_hours = {data.filter_hours}")
+        return web.Response()
+
+    async def blu_home_control(self, request):
+        s_value = request.rel_url.query['s']
+        shell = self._select_shell(s_value)
+        comfort_level = 5
+        operation_mode = 1
+        if shell:
+            comfort_level = shell.comfort_level() or comfort_level
+            operation_mode = shell.operation_mode() or operation_mode
+        else:
+            _LOGGER.warn(f"Could not find shell for serial number {s_value}")
+        response = f"heart__beat11{comfort_level}{operation_mode}\n"
+        _LOGGER.info(f"Received control request with s = {s_value}, b = {request.rel_url.query['b']}, response was {response}")
+        return web.Response(text = response)
+
+    def _extract_version(self, s):
+        # s = '1x1x57225y2x22x0'
+        parts = s.split('y')
+        return parts[1]
+
+    def _select_shell(self, s):
+        # s = '1x1x57225y2x22x0'
+        parts = s.split('y')
+        serial_parts = parts[0].split('x')
+        serial_no = serial_parts[2]
+        shells = self._hass.data.setdefault(DOMAIN, {})
+        return shells[serial_no]
+
+    async def start_server(self):
+        app = web.Application()
+        app.add_routes([web.get('/apps/data/blucontrol/', self.blu_home_index)])
+        app.add_routes([web.get('/apps/data/blucontrol/control/', self.blu_home_control)])
+        runner = web.AppRunner(app, access_log=None)
+        await runner.setup()
+        http_site = web.TCPSite(runner, port=BLUHOME_CONNECT_PORT)
+        try:
+            await http_site.start()
+            _LOGGER.info("Started HTTP webserver on port %s", BLUHOME_CONNECT_PORT)
+        except OSError as error:
+            _LOGGER.error("Failed to create HTTP server at port %d: %s", BLUHOME_CONNECT_PORT, error)
+
 
 async def async_setup(hass, config):
+    blu_home = BluHomeConnectServer(hass)
+    await blu_home.start_server()
+
     async def async_fetch_data(service: ServiceCall) -> None:
         shells = hass.data.setdefault(DOMAIN, {})
 
@@ -86,7 +153,12 @@ class FreeAirConnectShell:
 
     def _fetch(self):
         self._fac.fetch()
+#        dispatcher_send(self._hass, UPDATE_SENSORS_SIGNAL)
+
+    def parse(self, encrypted_data, timestamp, version, version_fa100):
+        data = self._fac.parse(encrypted_data, timestamp, version, version_fa100)
         dispatcher_send(self._hass, UPDATE_SENSORS_SIGNAL)
+        return data
 
     async def set_comfort_level(self, value):
         l = lambda: self._fac.set_comfort_level(value)
@@ -95,6 +167,12 @@ class FreeAirConnectShell:
     async def set_operation_mode(self, value):
         l = lambda: self._fac.set_operation_mode(value)
         await self._hass.async_add_executor_job(l)
+
+    def operation_mode(self):
+        return self._fac._operation_mode
+
+    def comfort_level(self):
+        return self._fac._comfort_level
 
     @property
     def serial_no(self):

--- a/custom_components/freeair_connect/__init__.py
+++ b/custom_components/freeair_connect/__init__.py
@@ -71,6 +71,7 @@ class BluHomeConnectServer:
         site = web.TCPSite(runner, port=BLUHOME_CONNECT_PORT)
         try:
             await site.start()
+            self._hass.data[f"{DOMAIN}_server_runner"] = runner
             _LOGGER.info("Started HTTP server on port %s", BLUHOME_CONNECT_PORT)
         except OSError as error:
             _LOGGER.error("Failed to start HTTP server on port %d: %s", BLUHOME_CONNECT_PORT, error)
@@ -120,11 +121,17 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry):
     unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
     if unload_ok:
         shells = hass.data[DOMAIN]
-
         del shells[entry.data[CONF_SERIAL_NO]]
 
+        # Stop server if no remaining shells need it
+        if not any(s._server_mode for s in shells.values()):
+            runner = hass.data.pop(f"{DOMAIN}_server_runner", None)
+            if runner:
+                await runner.cleanup()
+                _LOGGER.info("Stopped HTTP server")
+            hass.data.pop(f"{DOMAIN}_server_started", None)
+
         if len(shells) == 0:
-            # also remove shells if not used by any entry any more
             del hass.data[DOMAIN]
 
     return unload_ok

--- a/custom_components/freeair_connect/__init__.py
+++ b/custom_components/freeair_connect/__init__.py
@@ -113,7 +113,13 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
+    entry.async_on_unload(entry.add_update_listener(_async_options_updated))
+
     return True
+
+
+async def _async_options_updated(hass: HomeAssistant, entry: ConfigEntry) -> None:
+    await hass.config_entries.async_reload(entry.entry_id)
 
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry):

--- a/custom_components/freeair_connect/config_flow.py
+++ b/custom_components/freeair_connect/config_flow.py
@@ -5,7 +5,26 @@ Used by UI to setup integration.
 import voluptuous as vol
 from homeassistant import config_entries
 
-from .const import CONF_PASSWORD, CONF_SERIAL_NO, DOMAIN
+from .const import CONF_PASSWORD, CONF_SERIAL_NO, CONF_SERVER_MODE, DOMAIN
+
+
+class FreeAirOptionsFlowHandler(config_entries.OptionsFlow):
+    """Options flow to change settings after initial setup."""
+
+    async def async_step_init(self, user_input=None):
+        current_server_mode = self.config_entry.options.get(
+            CONF_SERVER_MODE,
+            self.config_entry.data.get(CONF_SERVER_MODE, False),
+        )
+        if user_input is not None:
+            return self.async_create_entry(title="", data=user_input)
+
+        return self.async_show_form(
+            step_id="init",
+            data_schema=vol.Schema(
+                {vol.Optional(CONF_SERVER_MODE, default=current_server_mode): bool}
+            ),
+        )
 
 
 class FreeAirConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  # type: ignore
@@ -15,6 +34,10 @@ class FreeAirConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  # type: igno
 
     def __init__(self):
         self._source_name = None
+
+    @staticmethod
+    def async_get_options_flow(config_entry):
+        return FreeAirOptionsFlowHandler()
 
     async def async_step_user(self, user_input=None):
         """Handle the start of the config flow.
@@ -27,7 +50,11 @@ class FreeAirConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  # type: igno
         """
         if user_input is None:
             data_schema = vol.Schema(
-                {vol.Required(CONF_SERIAL_NO): str, vol.Required(CONF_PASSWORD): str},
+                {
+                    vol.Required(CONF_SERIAL_NO): str,
+                    vol.Required(CONF_PASSWORD): str,
+                    vol.Optional(CONF_SERVER_MODE, default=False): bool,
+                },
             )
             return self.async_show_form(step_id="user", data_schema=data_schema)
 
@@ -41,5 +68,9 @@ class FreeAirConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  # type: igno
         title = f"FreeAir S/N: {serial_no}"
         return self.async_create_entry(
             title=title,
-            data={CONF_SERIAL_NO: serial_no, CONF_PASSWORD: user_input[CONF_PASSWORD]},
+            data={
+                CONF_SERIAL_NO: serial_no,
+                CONF_PASSWORD: user_input[CONF_PASSWORD],
+                CONF_SERVER_MODE: user_input.get(CONF_SERVER_MODE, False),
+            },
         )

--- a/custom_components/freeair_connect/const.py
+++ b/custom_components/freeair_connect/const.py
@@ -5,6 +5,7 @@ DOMAIN = "freeair_connect"
 
 CONF_SERIAL_NO = "serial_no"
 CONF_PASSWORD = "password"
+CONF_SERVER_MODE = "server_mode"
 
 UPDATE_SENSORS_SIGNAL = f"{DOMAIN}_update_sensors_signal"
 

--- a/custom_components/freeair_connect/translations/de.json
+++ b/custom_components/freeair_connect/translations/de.json
@@ -1,4 +1,14 @@
 {
+    "options": {
+      "step": {
+        "init": {
+          "description": "Im lokalen Server-Modus sendet das Gerät Daten direkt an Home Assistant (Port 80). Dazu muss die IP-Adresse von Home Assistant in der FreeAir USB-App am Gerät eingestellt werden.",
+          "data": {
+            "server_mode": "Lokalen Server aktivieren (Port 80)"
+          }
+        }
+      }
+    },
     "config": {
       "abort": {
         "already_configured": "Dieses Gerät ist bereits eingerichtet.",
@@ -6,9 +16,11 @@
       },
       "step": {
         "user": {
+          "description": "Im lokalen Server-Modus sendet das Gerät Daten direkt an Home Assistant (Port 80). Dazu muss die IP-Adresse von Home Assistant in der FreeAir USB-App am Gerät eingestellt werden.",
           "data": {
             "serial_no": "Seriennummer",
-            "password": "Passwort"
+            "password": "Passwort",
+            "server_mode": "Lokalen Server aktivieren (Port 80)"
           }
         }
       }

--- a/custom_components/freeair_connect/translations/en.json
+++ b/custom_components/freeair_connect/translations/en.json
@@ -1,4 +1,14 @@
 {
+    "options": {
+      "step": {
+        "init": {
+          "description": "In local server mode, the device sends data directly to Home Assistant (port 80). You need to configure the IP address of your Home Assistant instance in the FreeAir USB app on the device.",
+          "data": {
+            "server_mode": "Enable local server (port 80)"
+          }
+        }
+      }
+    },
     "config": {
       "abort": {
         "already_configured": "This market area is already configured.",
@@ -6,9 +16,11 @@
       },
       "step": {
         "user": {
+          "description": "In local server mode, the device sends data directly to Home Assistant (port 80). You need to configure the IP address of your Home Assistant instance in the FreeAir USB app on the device.",
           "data": {
             "serial_no": "Serial Number",
-            "password": "Password"
+            "password": "Password",
+            "server_mode": "Enable local server (port 80)"
           }
         }
       }


### PR DESCRIPTION
@BenRomberg mentioned in #21 that he built a server for the bluhome API.

I merged both ways and added a option for the local server mode.

The server-IP has to be configured with the USB-App.

With the bluhome API you get the sensor values each minute. 

I tested it with a device with software version 2.24.