### PR TITLE
Add configuration option for local server port

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Instead of polling the freeair-connect.de cloud, the integration can run a local
 1. Enable **"Lokalen Server aktivieren"** / **"Enable local server"** during setup, or afterwards via **Settings → Integrations → FreeAir Connect → Configure**.
 2. Using the FreeAir USB app, configure the device's server address to the IP address of your Home Assistant instance.
 
-> **Note:** The local server listens on port 80. Make sure this port is not already in use on your Home Assistant host.
+> **Note:** The local server listens on port 80 by default. Make sure this port is not already in use on your Home Assistant host. You can change the port in the integration options, but only do so when running a reverse proxy in front of the server, since the device expects to reach the server on port 80.
 
 ## Refresh Service
 

--- a/custom_components/freeair_connect/__init__.py
+++ b/custom_components/freeair_connect/__init__.py
@@ -12,7 +12,9 @@ from homeassistant.core import HomeAssistant, ServiceCall, callback
 from homeassistant.helpers.dispatcher import dispatcher_send
 from homeassistant.helpers.event import async_track_time_interval
 
-from .const import CONF_PASSWORD, CONF_SERIAL_NO, CONF_SERVER_MODE, DOMAIN, UPDATE_SENSORS_SIGNAL
+from .const import (CONF_LOCAL_SERVER_PORT, CONF_PASSWORD, CONF_SERIAL_NO,
+                    CONF_SERVER_MODE, DEFAULT_LOCAL_SERVER_PORT, DOMAIN,
+                    UPDATE_SENSORS_SIGNAL)
 from .FreeAir import Connect
 
 _LOGGER = logging.getLogger(__name__)
@@ -20,12 +22,11 @@ _LOGGER = logging.getLogger(__name__)
 
 PLATFORMS = ["sensor", "binary_sensor", "number", "select"]
 
-BLUHOME_CONNECT_PORT = 80
-
 
 class BluHomeConnectServer:
-    def __init__(self, hass: HomeAssistant):
+    def __init__(self, hass: HomeAssistant, port: int = DEFAULT_LOCAL_SERVER_PORT):
         self._hass = hass
+        self._port = port
 
     async def blu_home_index(self, request):
         s_value = request.rel_url.query["s"]
@@ -68,13 +69,13 @@ class BluHomeConnectServer:
         app.add_routes([web.get("/apps/data/blucontrol/control/", self.blu_home_control)])
         runner = web.AppRunner(app, access_log=None)
         await runner.setup()
-        site = web.TCPSite(runner, port=BLUHOME_CONNECT_PORT)
+        site = web.TCPSite(runner, port=self._port)
         try:
             await site.start()
             self._hass.data[f"{DOMAIN}_server_runner"] = runner
-            _LOGGER.info("Started HTTP server on port %s", BLUHOME_CONNECT_PORT)
+            _LOGGER.info("Started HTTP server on port %s", self._port)
         except OSError as error:
-            _LOGGER.error("Failed to start HTTP server on port %d: %s", BLUHOME_CONNECT_PORT, error)
+            _LOGGER.error("Failed to start HTTP server on port %d: %s", self._port, error)
 
 
 async def async_setup(hass, config):
@@ -97,6 +98,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     serial_no = entry.data[CONF_SERIAL_NO]
     server_mode = entry.options.get(CONF_SERVER_MODE, entry.data.get(CONF_SERVER_MODE, False))
+    port = entry.options.get(CONF_LOCAL_SERVER_PORT, entry.data.get(CONF_LOCAL_SERVER_PORT, DEFAULT_LOCAL_SERVER_PORT))
 
     shell = FreeAirConnectShell(
         hass, serial_no=serial_no, password=entry.data[CONF_PASSWORD], server_mode=server_mode
@@ -105,7 +107,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     if server_mode:
         if not hass.data.get(f"{DOMAIN}_server_started"):
-            server = BluHomeConnectServer(hass)
+            server = BluHomeConnectServer(hass, port)
             await server.start_server()
             hass.data[f"{DOMAIN}_server_started"] = True
     else:

--- a/custom_components/freeair_connect/config_flow.py
+++ b/custom_components/freeair_connect/config_flow.py
@@ -5,7 +5,10 @@ Used by UI to setup integration.
 import voluptuous as vol
 from homeassistant import config_entries
 
-from .const import CONF_PASSWORD, CONF_SERIAL_NO, CONF_SERVER_MODE, DOMAIN
+from .const import (CONF_LOCAL_SERVER_PORT, CONF_PASSWORD, CONF_SERIAL_NO,
+                    CONF_SERVER_MODE, DEFAULT_LOCAL_SERVER_PORT, DOMAIN)
+
+PORT_SCHEMA = vol.All(vol.Coerce(int), vol.Range(min=1, max=65535))
 
 
 class FreeAirOptionsFlowHandler(config_entries.OptionsFlow):
@@ -16,13 +19,20 @@ class FreeAirOptionsFlowHandler(config_entries.OptionsFlow):
             CONF_SERVER_MODE,
             self.config_entry.data.get(CONF_SERVER_MODE, False),
         )
+        current_port = self.config_entry.options.get(
+            CONF_LOCAL_SERVER_PORT,
+            self.config_entry.data.get(CONF_LOCAL_SERVER_PORT, DEFAULT_LOCAL_SERVER_PORT),
+        )
         if user_input is not None:
             return self.async_create_entry(title="", data=user_input)
 
         return self.async_show_form(
             step_id="init",
             data_schema=vol.Schema(
-                {vol.Optional(CONF_SERVER_MODE, default=current_server_mode): bool}
+                {
+                    vol.Optional(CONF_SERVER_MODE, default=current_server_mode): bool,
+                    vol.Optional(CONF_LOCAL_SERVER_PORT, default=current_port): PORT_SCHEMA,
+                }
             ),
         )
 
@@ -54,6 +64,7 @@ class FreeAirConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  # type: igno
                     vol.Required(CONF_SERIAL_NO): str,
                     vol.Required(CONF_PASSWORD): str,
                     vol.Optional(CONF_SERVER_MODE, default=False): bool,
+                    vol.Optional(CONF_LOCAL_SERVER_PORT, default=DEFAULT_LOCAL_SERVER_PORT): PORT_SCHEMA,
                 },
             )
             return self.async_show_form(step_id="user", data_schema=data_schema)
@@ -72,5 +83,6 @@ class FreeAirConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  # type: igno
                 CONF_SERIAL_NO: serial_no,
                 CONF_PASSWORD: user_input[CONF_PASSWORD],
                 CONF_SERVER_MODE: user_input.get(CONF_SERVER_MODE, False),
+                CONF_LOCAL_SERVER_PORT: user_input.get(CONF_LOCAL_SERVER_PORT, DEFAULT_LOCAL_SERVER_PORT),
             },
         )

--- a/custom_components/freeair_connect/const.py
+++ b/custom_components/freeair_connect/const.py
@@ -6,6 +6,9 @@ DOMAIN = "freeair_connect"
 CONF_SERIAL_NO = "serial_no"
 CONF_PASSWORD = "password"
 CONF_SERVER_MODE = "server_mode"
+CONF_LOCAL_SERVER_PORT = "local_server_port"
+
+DEFAULT_LOCAL_SERVER_PORT = 80
 
 UPDATE_SENSORS_SIGNAL = f"{DOMAIN}_update_sensors_signal"
 

--- a/custom_components/freeair_connect/translations/de.json
+++ b/custom_components/freeair_connect/translations/de.json
@@ -2,9 +2,13 @@
     "options": {
       "step": {
         "init": {
-          "description": "Im lokalen Server-Modus sendet das Gerät Daten direkt an Home Assistant (Port 80). Dazu muss die IP-Adresse von Home Assistant in der FreeAir USB-App am Gerät eingestellt werden.",
+          "description": "Im lokalen Server-Modus sendet das Gerät Daten direkt an Home Assistant. Dazu muss die IP-Adresse von Home Assistant in der FreeAir USB-App am Gerät eingestellt werden.",
           "data": {
-            "server_mode": "Lokalen Server aktivieren (Port 80)"
+            "server_mode": "Lokalen Server aktivieren",
+            "local_server_port": "Port des lokalen Servers"
+          },
+          "data_description": {
+            "local_server_port": "Nur ändern, wenn ein Reverse-Proxy vor dem Server betrieben wird. Das Gerät erwartet den Server auf Port 80."
           }
         }
       }
@@ -16,11 +20,15 @@
       },
       "step": {
         "user": {
-          "description": "Im lokalen Server-Modus sendet das Gerät Daten direkt an Home Assistant (Port 80). Dazu muss die IP-Adresse von Home Assistant in der FreeAir USB-App am Gerät eingestellt werden.",
+          "description": "Im lokalen Server-Modus sendet das Gerät Daten direkt an Home Assistant. Dazu muss die IP-Adresse von Home Assistant in der FreeAir USB-App am Gerät eingestellt werden.",
           "data": {
             "serial_no": "Seriennummer",
             "password": "Passwort",
-            "server_mode": "Lokalen Server aktivieren (Port 80)"
+            "server_mode": "Lokalen Server aktivieren",
+            "local_server_port": "Port des lokalen Servers"
+          },
+          "data_description": {
+            "local_server_port": "Nur ändern, wenn ein Reverse-Proxy vor dem Server betrieben wird. Das Gerät erwartet den Server auf Port 80."
           }
         }
       }

--- a/custom_components/freeair_connect/translations/en.json
+++ b/custom_components/freeair_connect/translations/en.json
@@ -2,9 +2,13 @@
     "options": {
       "step": {
         "init": {
-          "description": "In local server mode, the device sends data directly to Home Assistant (port 80). You need to configure the IP address of your Home Assistant instance in the FreeAir USB app on the device.",
+          "description": "In local server mode, the device sends data directly to Home Assistant. You need to configure the IP address of your Home Assistant instance in the FreeAir USB app on the device.",
           "data": {
-            "server_mode": "Enable local server (port 80)"
+            "server_mode": "Enable local server",
+            "local_server_port": "Local server port"
+          },
+          "data_description": {
+            "local_server_port": "Only change this when running a reverse proxy in front of the server. The device expects to reach the server on port 80."
           }
         }
       }
@@ -16,11 +20,15 @@
       },
       "step": {
         "user": {
-          "description": "In local server mode, the device sends data directly to Home Assistant (port 80). You need to configure the IP address of your Home Assistant instance in the FreeAir USB app on the device.",
+          "description": "In local server mode, the device sends data directly to Home Assistant. You need to configure the IP address of your Home Assistant instance in the FreeAir USB app on the device.",
           "data": {
             "serial_no": "Serial Number",
             "password": "Password",
-            "server_mode": "Enable local server (port 80)"
+            "server_mode": "Enable local server",
+            "local_server_port": "Local server port"
+          },
+          "data_description": {
+            "local_server_port": "Only change this when running a reverse proxy in front of the server. The device expects to reach the server on port 80."
           }
         }
       }


### PR DESCRIPTION
This PR adds a configuration option that allows customizing the port on which the local server runs and updates the README and translation strings accordingly.

Being able to change the local server's port is useful for setups that run a reverse proxy (e.g. Nginx Proxy Manager) on the Home Assistant host, which already binds port 80. I tested this on my own instance by switching the port to `4000` and setting up a "Custom location" in Nginx Proxy Manager that routes requests for `/apps/data/blucontrol/` to the port. Everything seems to be working great.

| Initial Setup |  Options |
|--------|--------|
| <img width="892" height="971" alt="image" src="https://github.com/user-attachments/assets/f6c70956-3afa-4eae-831f-d5f2a42cb4f8" /> | <img width="889" height="704" alt="image" src="https://github.com/user-attachments/assets/ff704645-1c86-4e02-944b-82c598910d4a" />|


I attempted to format the code with `black` and `isort` to match the rest of the codebase, but this reformatted a bunch of files I didn't touch, so I just tried to somewhat match the existing style by hand.